### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/NicoLeputois/8fb9259b-e5d7-48b0-a9af-3338a225dc2d/2467821f-6fa9-4c07-bfc1-8018364de53a/_apis/work/boardbadge/0fa5f5ae-7d61-417d-aaf2-81c9869a33b4)](https://dev.azure.com/NicoLeputois/8fb9259b-e5d7-48b0-a9af-3338a225dc2d/_boards/board/t/2467821f-6fa9-4c07-bfc1-8018364de53a/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/NicoLeputois/8fb9259b-e5d7-48b0-a9af-3338a225dc2d/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.